### PR TITLE
Add documentation for the extended consumes section for stubbing

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -370,7 +370,7 @@ contracts:
 {% endtabs %}
 
 As per the above configuration, the specs `api_order_v1.yaml` and `api_user_v1.yaml` will run on port 9000 and the spec `api_auth_v1.yaml` will run on port 9001.
-You can also specify `host`, `basePath`, and even the complete `baseUrl` in the `consumes` field. For more details, refer to the [Service Virtualization](/documentation/service_virtualization_tutorial#specmatic-stubs-with-base-url-host-port-and-path-configuration)
+You can also specify `host`, `basePath`, and even the complete `baseUrl` in the `consumes` field. For more details, refer to the [Service Virtualization](/documentation/service_virtualization_tutorial#specmatic-configuration-with-base-url-host-port-and-path)
 
 #### Source control authentication
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -370,6 +370,7 @@ contracts:
 {% endtabs %}
 
 As per the above configuration, the specs `api_order_v1.yaml` and `api_user_v1.yaml` will run on port 9000 and the spec `api_auth_v1.yaml` will run on port 9001.
+You can also specify `host`, `basePath`, and even the complete `baseUrl` in the `consumes` field. For more details, refer to the [Service Virtualization](/documentation/service_virtualization_tutorial#specmatic-stubs-with-base-url-host-port-and-path-configuration)
 
 #### Source control authentication
 

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -51,27 +51,26 @@ Service Virtualization
   - [Precedence Across Types Of Examples](#precedence-across-types-of-examples)
   - [Checking Health Status Of Stub Server](#checking-health-status-of-stub-server)
       - [Example `curl` Request:](#example-curl-request)
-  - [Specmatic Stubs with Base URL, Host, Port, and Path Configuration](#specmatic-stubs-with-base-url-host-port-and-path-configuration)
-      - [Specifying Host](#specifying-host)
-      - [Specifying Port](#specifying-port)
-      - [Specifying Base Path](#specifying-base-path)
-      - [Specifying Combination of Host, Port, and Base Path](#specifying-combination-of-host-port-and-base-path)
-      - [Specifying Base URL](#specifying-base-url)
-      - [Customizing the Default Base URL](#customizing-the-default-base-url)
+  - [Specmatic Configuration with Base URL, Host, Port, and Path](#specmatic-configuration-with-base-url-host-port-and-path)
+    - [Specifying Host](#specifying-host)
+    - [Specifying Port](#specifying-port)
+    - [Specifying Base Path](#specifying-base-path)
+    - [Specifying Combination of Host, Port, and Base Path](#specifying-combination-of-host-port-and-base-path)
+    - [Specifying Base URL](#specifying-base-url)
+    - [Customizing the Default Base URL](#customizing-the-default-base-url)
   - [Running Specmatic Stubs on Multiple BaseURLs](#running-specmatic-stubs-on-multiple-baseurls)
-      - [Overview](#overview-1)
-      - [Directory Structure](#directory-structure)
-      - [Specmatic Configuration](#specmatic-configuration)
-        - [specmatic.yaml](#specmaticyaml)
-      - [API Specifications](#api-specifications)
-        - [imported\_product.yaml](#imported_productyaml)
-        - [exported\_product.yaml](#exported_productyaml)
-      - [Examples](#examples)
-        - [post\_imported\_product.json](#post_imported_productjson)
-        - [post\_exported\_product.json](#post_exported_productjson)
-        - [Run the stub server](#run-the-stub-server)
-      - [Example Requests](#example-requests)
-      - [Benefits](#benefits)
+    - [Overview](#overview-1)
+    - [Directory Structure](#directory-structure)
+    - [Specmatic Configuration](#specmatic-configuration)
+    - [API Specifications](#api-specifications)
+      - [imported\_product.yaml](#imported_productyaml)
+      - [exported\_product.yaml](#exported_productyaml)
+    - [Examples](#examples)
+      - [post\_imported\_product.json](#post_imported_productjson)
+      - [post\_exported\_product.json](#post_exported_productjson)
+    - [Run the stub server](#run-the-stub-server)
+    - [Example Requests](#example-requests)
+    - [Benefits](#benefits)
   - [Sample Java Project](#sample-java-project)
 
 
@@ -1785,14 +1784,14 @@ paths:
                       - UP
                     example: UP
 ```
-## Specmatic Stubs with Base URL, Host, Port, and Path Configuration
+## Specmatic Configuration with Base URL, Host, Port, and Path
 
-By default, Specmatic stub servers run on `http://0.0.0.0:9000`<br/>
+By default, Specmatic stub servers run on `http://0.0.0.0:9000` *(Default BaseURL)*<br/>
 However, you can customize the endpoint by specifying the `host`, `port`, `basePath`, or the complete `baseUrl` according to your requirements in the Specmatic Config.
 - Specifying only `host`, `port`, or `basePath` will auto-fill missing parts from the default base URL.
 - If `baseUrl` is specified, it will be used directly.
 
-#### Specifying Host
+### Specifying Host
 With the following configuration, the stub server will run on `127.0.0.1` rather than the default host `0.0.0.0`
 
 ```yaml
@@ -1805,7 +1804,7 @@ contracts:
     - "com/order.yaml" # Final endpoint: http://127.0.0.1:9000
 ```
 
-#### Specifying Port
+### Specifying Port
 With the following configuration, the stub server will run on port `5000` rather than the default port `9000`
 
 ```yaml
@@ -1818,7 +1817,7 @@ contracts:
     - "com/order.yaml" # Final endpoint: http://0.0.0.0:5000
 ```
 
-#### Specifying Base Path
+### Specifying Base Path
 With the following configuration, the stub server will run on `/api/v2` rather than the default base-path `/`
 
 ```yaml
@@ -1831,7 +1830,7 @@ contracts:
     - "com/order.yaml" # Final endpoint: http://0.0.0.0:9000/api/v2
 ```
 
-#### Specifying Combination of Host, Port, and Base Path
+### Specifying Combination of Host, Port, and Base Path
 The `host`, `port`, and `basePath` can be specified individually or in combination. 
 With the following configuration, the stub server will run at `http://127.0.0.1:5000/api/v2`.
 
@@ -1847,7 +1846,7 @@ contracts:
     - "com/order.yaml" # Final endpoint: http://127.0.0.1:5000/api/v2
 ```
 
-#### Specifying Base URL
+### Specifying Base URL
 To directly configure the endpoint, you can define the `baseUrl`. 
 With the following configuration, the stub server will run at `http://127.0.0.1:5000/api/v2` rather than the default base URL.
 
@@ -1861,10 +1860,10 @@ contracts:
     - "com/order.yaml" # Final endpoint: http://127.0.0.1:5000/api/v2
 ```
 
-**Note**: You can either provide a `baseUrl` or specify one of or a combination of `host`, `port`, and `basePath`.
+> **Note**: You can either provide a `baseUrl` or specify one of or a combination of `host`, `port`, and `basePath`.
 They are mutually exclusive and cannot be used together for the same stub configuration.
 
-#### Customizing the Default Base URL
+### Customizing the Default Base URL
 
 The default base URL can also be customized:
 - Through command-line arguments using `--host` and `--port` arguments
@@ -1872,12 +1871,12 @@ The default base URL can also be customized:
 
 ## Running Specmatic Stubs on Multiple BaseURLs
 
-#### Overview
+### Overview
 This setup demonstrates how to run Specmatic stubs on multiple baseURLs for multiple specifications.<br/>
 This allows serving different APIs on their respective baseURLs while keeping their examples specific to each specification.<br/>
 **Note:** This is not limited to `baseUrl` but can be extended to `host`, `port`, and `basePath` as well.
 
-#### Directory Structure
+### Directory Structure
 ```
 project-root/
 │── specmatic.yaml
@@ -1891,8 +1890,7 @@ project-root/
 │       ├── post_exported_product.json
 ```
 
-#### Specmatic Configuration
-##### specmatic.yaml
+### Specmatic Configuration
 ```yaml
 version: 2
 contracts:
@@ -1904,8 +1902,8 @@ contracts:
 ```
 Note: The `imported_product` spec does not have a baseURL assigned, so it defaults to `http://0.0.0.0:9000`, whereas `exported_product` runs on `http://0.0.0.0:9001/exported`.
 
-#### API Specifications
-##### imported_product.yaml
+### API Specifications
+#### imported_product.yaml
 ```yaml
 openapi: 3.0.3
 info:
@@ -1942,7 +1940,7 @@ paths:
                     type: string
 ```
 
-##### exported_product.yaml
+#### exported_product.yaml
 ```yaml
 openapi: 3.0.3
 info:
@@ -1979,8 +1977,8 @@ paths:
                     type: string
 ```
 
-#### Examples
-##### post_imported_product.json
+### Examples
+#### post_imported_product.json
 ```json
 {
   "http-request": {
@@ -2002,7 +2000,7 @@ paths:
 }
 ```
 
-##### post_exported_product.json
+#### post_exported_product.json
 ```json
 {
   "http-request": {
@@ -2024,7 +2022,7 @@ paths:
 }
 ```
 
-##### Run the stub server
+### Run the stub server
 Once we have this setup, we can run the Specmatic stub server by running the following command in the `project-root` directory:
 {% tabs test %}
 {% tab test java %}
@@ -2046,7 +2044,7 @@ docker run -p 9000:9000 -p 9001:9001 -v "$(pwd)/imported_product:/usr/src/app/im
 
 This will start the Specmatic stub server on baseURLs `http://0.0.0.0:9000` and `http://0.0.0.0:9001/exported` for the `imported_product` and `exported_product` APIs, respectively.
 
-#### Example Requests
+### Example Requests
 
 Hitting the imported_product API on default baseURL http://localhost:9000
 ```sh
@@ -2074,7 +2072,7 @@ curl -X POST http://localhost:9001/exported/products -H "Content-Type: applicati
 }
 ```
 
-#### Benefits
+### Benefits
 - **BaseURL-based segregation:** Each spec runs on a dedicated baseURL, ensuring clear separation.
 - **Spec-specific examples:** Requests return expected responses per specification.
 - **Flexibility:** Allows hosting multiple versions or separate APIs without conflict.

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -52,10 +52,13 @@ Service Virtualization
   - [Checking Health Status Of Stub Server](#checking-health-status-of-stub-server)
       - [Example `curl` Request:](#example-curl-request)
   - [Specmatic Stubs with Base URL, Host, Port, and Path Configuration](#specmatic-stubs-with-base-url-host-port-and-path-configuration)
-    - [Customizing the Stub Server](#customizing-the-stub-server)
-    - [Example Specmatic Config](#example-specmatic-config)
-  - [Running Specmatic Stub with a Prefixed Base Path](#running-specmatic-stub-with-a-prefixed-base-path)
-  - [Running Specmatic Stubs on Different BaseURLs](#running-specmatic-stubs-on-different-baseurls)
+      - [Specifying Host](#specifying-host)
+      - [Specifying Port](#specifying-port)
+      - [Specifying Base Path](#specifying-base-path)
+      - [Specifying Combination of Host, Port, and Base Path](#specifying-combination-of-host-port-and-base-path)
+      - [Specifying Base URL](#specifying-base-url)
+      - [Customizing the Default Base URL](#customizing-the-default-base-url)
+  - [Running Specmatic Stubs on Multiple BaseURLs](#running-specmatic-stubs-on-multiple-baseurls)
       - [Overview](#overview-1)
       - [Directory Structure](#directory-structure)
       - [Specmatic Configuration](#specmatic-configuration)
@@ -1784,101 +1787,95 @@ paths:
 ```
 ## Specmatic Stubs with Base URL, Host, Port, and Path Configuration
 
-When simulating APIs, it is crucial to have control over the execution environment of your stub servers. You might need to:
+By default, Specmatic stub servers run on `http://0.0.0.0:9000`<br/>
+However, you can customize the endpoint by specifying the `host`, `port`, `basePath`, or the complete `baseUrl` according to your requirements in the Specmatic Config.
+- Specifying only `host`, `port`, or `basePath` will auto-fill missing parts from the default base URL.
+- If `baseUrl` is specified, it will be used directly.
 
-- Quickly launch a stub on a default URL for local development purposes.
-- Execute stubs on designated ports when multiple services are operational.
-- Define a specific base path to align with your API routes.
-- Tailor the complete baseUrl to precisely fit the requirements of your test environments.
-
-Specmatic allow you to configure this behavior flexibly, based on your needs, without any complicated setup.
-
-### Customizing the Stub Server
-
-You can customize specific aspects of the server configuration by utilizing the following keys in the `consumes` section of the Specmatic Config:
-
-- `baseUrl`: Define the full URL, which includes the scheme, host and optionally port and path
-- `port`: Specifies only the port, the rest will utilize default values
-- `host`: Specify only the host, the rest will utilize default values
-- `basePath`: Specifies only the basePath, the rest will utilize default values
-
-The keys can be specified either individually or in combination. For more information on the override functionality, please consult the table below.  
-**Note**: `baseUrl` is mutually exclusive with the other fields — you must provide either `baseUrl` or one of or a combination of host, port and basePath.
-
-| Key      | What it Overrides              | Defaults Used      |
-|----------|--------------------------------|--------------------|
-| baseUrl  | Scheme, Host, Port, Path (All) | None               |
-| host     | Host only                      | Scheme, Port, Path |
-| port     | Port only                      | Scheme, Host, Path |
-| basePath | Path only                      | Scheme, Host, Port |
-
-The default `baseUrl` can be customized through command-line arguments using `--host` and `--port`,
-or by configuring the `SPECMATIC_BASE_URL` system property when using the programmatic approach.
-This provides the flexibility to easily adapt your stub servers to different local and remote environments as needed.
-
-### Example Specmatic Config
+#### Specifying Host
+With the following configuration, the stub server will run on `127.0.0.1` rather than the default host `0.0.0.0`
 
 ```yaml
 version: "2"
 contracts:
-  - filesystem:
-      directory: "contracts"
-    consumes:
-      - "com/order.yaml" # Default baseUrl: http://0.0.0.0:9000
-      - baseUrl: "http://127.0.0.1:8080/api/v2" 
-        specs:
-          - "com/order.yaml" # Overridden baseUrl: http://127.0.0.1:8080/api/v2
-      - host: "127.0.0.1"
-        specs:
-          - "com/order.yaml" # Overridden host: http://127.0.0.1:9000
-      - port: 8080
-        specs:
-          - "com/order.yaml" # Overridden port: http://0.0.0.0:8080
-      - basePath: "/api/v2"
-        specs:
-          - "com/order.yaml" # Overridden basePath: http://0.0.0.0:9000/api/v2
-      - host: "127.0.0.1"
-        port: 8080
-        specs:
-          - "com/order.yaml" # Overridden host and port: http://127.0.0.1:8080
-      - host: "127.0.0.1"
-        basePath: "/api/v2"
-        specs:
-          - "com/order.yaml" # Overridden host and basePath: http://127.0.0.1:9000/api/v2
-      - port: 8080
-        basePath: "/api/v2"
-        specs:
-          - "com/order.yaml" # Overridden port and basePath: http://0.0.0.0:8080/api/v2
-      - host: "127.0.0.1"
-        port: 8080
-        basePath: "/api/v2"
-        specs:
-          - "com/order.yaml" # Overridden host, port, and basePath: http://127.0.0.1:8080/api/v2
+- filesystem:
+  consumes:
+  - host: "127.0.0.1"
+    specs:
+    - "com/order.yaml" # Final endpoint: http://127.0.0.1:9000
 ```
 
-## Running Specmatic Stub with a Prefixed Base Path
-
-When building APIs, it is common practice to organize endpoints under a base path, such as `/api/v2` for versioned APIs. To support this, Specmatic allows you to configure a base URL without necessitating changes to the underlying contract paths, this can easily be achieved by setting the `baseUrl` field in the Specmatic Config.
+#### Specifying Port
+With the following configuration, the stub server will run on port `5000` rather than the default port `9000`
 
 ```yaml
-version: 2
+version: "2"
 contracts:
-  - consumes:
-    - baseUrl: http://localhost:9000/api/v2
-      specs:
-        - path/to/specification.yml
+- filesystem:
+  consumes:
+  - port: 5000
+    specs:
+    - "com/order.yaml" # Final endpoint: http://0.0.0.0:5000
 ```
 
-In this setup:
-- The stub server will be accessible at `http://localhost:9000/api/v2/`
-- All endpoints defined in your contract will automatically be available under the `/api/v2` prefix.
+#### Specifying Base Path
+With the following configuration, the stub server will run on `/api/v2` rather than the default base-path `/`
 
-For example, if your contract defines an endpoint at `/users`, it will be available at `http://localhost:9000/api/v2/users` when stubbed, without requiring any modifications to the contract itself, Further information regarding `baseUrl` can be found in the section below, including details on how to run multiple stub servers with different base URLs.
+```yaml
+version: "2"
+contracts:
+- filesystem:
+  consumes:
+  - basePath: "/api/v2"
+    specs:
+    - "com/order.yaml" # Final endpoint: http://0.0.0.0:9000/api/v2
+```
 
-## Running Specmatic Stubs on Different BaseURLs
+#### Specifying Combination of Host, Port, and Base Path
+The `host`, `port`, and `basePath` can be specified individually or in combination. 
+With the following configuration, the stub server will run at `http://127.0.0.1:5000/api/v2`.
+
+```yaml
+version: "2"
+contracts:
+- filesystem:
+  consumes:
+  - host: "127.0.0.1"
+    port: 5000
+    basePath: "/api/v2"
+    specs:
+    - "com/order.yaml" # Final endpoint: http://127.0.0.1:5000/api/v2
+```
+
+#### Specifying Base URL
+To directly configure the endpoint, you can define the `baseUrl`. 
+With the following configuration, the stub server will run at `http://127.0.0.1:5000/api/v2` rather than the default base URL.
+
+```yaml
+version: "2"
+contracts:
+- filesystem:
+  consumes:
+  - baseUrl: "http://127.0.0.1:5000/api/v2"
+    specs:
+    - "com/order.yaml" # Final endpoint: http://127.0.0.1:5000/api/v2
+```
+
+**Note**: You can either provide a `baseUrl` or specify one of or a combination of `host`, `port`, and `basePath`.
+They are mutually exclusive and cannot be used together for the same stub configuration.
+
+#### Customizing the Default Base URL
+
+The default base URL can also be customized:
+- Through command-line arguments using `--host` and `--port` arguments
+- Or by configuring the `SPECMATIC_BASE_URL` system property when using the programmatic approach
+
+## Running Specmatic Stubs on Multiple BaseURLs
 
 #### Overview
-This setup demonstrates how to run Specmatic stubs on different baseURLs for different specifications. This allows serving different APIs on their respective baseURLs while keeping their examples specific to each specification.
+This setup demonstrates how to run Specmatic stubs on multiple baseURLs for multiple specifications.<br/>
+This allows serving different APIs on their respective baseURLs while keeping their examples specific to each specification.<br/>
+**Note:** This is not limited to `baseUrl` but can be extended to `host`, `port`, and `basePath` as well.
 
 #### Directory Structure
 ```

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -51,6 +51,9 @@ Service Virtualization
   - [Precedence Across Types Of Examples](#precedence-across-types-of-examples)
   - [Checking Health Status Of Stub Server](#checking-health-status-of-stub-server)
       - [Example `curl` Request:](#example-curl-request)
+    - [Specmatic Stubs with Base URL, Host, Port, and Path Configuration](#specmatic-stubs-with-base-url-host-port-and-path-configuration)
+      - [Customizing the Stub Server](#customizing-the-stub-server)
+      - [Example Specmatic Config](#example-specmatic-config)
     - [Running Specmatic Stubs on Different BaseURLs](#running-specmatic-stubs-on-different-baseurls)
       - [Overview](#overview-1)
       - [Directory Structure](#directory-structure)
@@ -1777,6 +1780,60 @@ paths:
                     enum:
                       - UP
                     example: UP
+```
+### Specmatic Stubs with Base URL, Host, Port, and Path Configuration
+
+When simulating APIs, it is crucial to have control over the execution environment of your stub servers. You might need to:
+
+- Quickly launch a stub on a default URL for local development purposes.
+- Execute stubs on designated ports when multiple services are operational.
+- Define a specific base path to align with your API routes.
+- Tailor the complete baseUrl to precisely fit the requirements of your test environments.
+
+Specmatic allow you to configure this behavior flexibly, based on your needs, without any complicated setup.
+
+#### Customizing the Stub Server
+
+You can customize specific aspects of the server configuration by utilizing the following keys in the `consumes` section of the Specmatic Config:
+
+- `baseUrl`: Define the full URL, which includes the scheme, host and optionally port and path
+- `port`: Specify only the port. The host and scheme will utilize default values
+- `host`: Specify only the host. The scheme and port will utilize default values
+- `basePath`: Indicate a base path under which the stubs will be served. The scheme, host, and port will utilize default values
+
+**Note:** If `baseUrl` is specified, the `host`, `port`, and `basePath` keys if present will be disregarded.
+Please refer to the order of precedence and the default values outlined below.
+
+| Key In Order Of Precedence | What it Overrides              | Defaults Used      |
+|----------------------------|--------------------------------|--------------------|
+| baseUrl                    | Scheme, Host, Port, Path (All) | None               |
+| host                       | Host only                      | Scheme, Port       |
+| port                       | Port only                      | Scheme, Host       |
+| basePath                   | Path only                      | Scheme, Host, Port |
+
+The default `baseUrl` can be customized through command-line arguments using `--host` and `--port`, which will construct the default `baseUrl`, or by configuring the `SPECMATIC_BASE_URL` system property. This provides the flexibility to easily adapt your stub servers to different local and remote environments as needed.
+
+#### Example Specmatic Config
+
+```yaml
+version: "2"
+contracts:
+  - filesystem:
+      directory: "contracts"
+    consumes:
+      - "com/order.yaml" # Utilizes the default baseUrl: http://0.0.0.0:9000
+      - baseUrl: "http://localhost:8080/api/v2" # Overrides the default baseUrl
+        specs:
+          - "com/order.yaml"
+      - host: "127.0.0.1" # Host is overridden; other settings remain as default
+        specs:
+          - "com/order.yaml"
+      - port: 8080 # Port is overridden; other settings remain as default
+        specs:
+          - "com/order.yaml"
+      - basePath: "/api/v2" # Path is overridden; scheme, host, and port remain as default
+        specs:
+          - "com/order.yaml"
 ```
 
 ### Running Specmatic Stubs on Different BaseURLs

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -1812,7 +1812,8 @@ The keys can be specified either individually or in combination. For more inform
 | port     | Port only                      | Scheme, Host, Path |
 | basePath | Path only                      | Scheme, Host, Port |
 
-The default `baseUrl` can be customized through command-line arguments using `--host` and `--port`, or by configuring the `SPECMATIC_BASE_URL` system property.
+The default `baseUrl` can be customized through command-line arguments using `--host` and `--port`,
+or by configuring the `SPECMATIC_BASE_URL` system property when using the programmatic approach.
 This provides the flexibility to easily adapt your stub servers to different local and remote environments as needed.
 
 ### Example Specmatic Config

--- a/documentation/service_virtualization_tutorial.md
+++ b/documentation/service_virtualization_tutorial.md
@@ -1797,21 +1797,22 @@ Specmatic allow you to configure this behavior flexibly, based on your needs, wi
 You can customize specific aspects of the server configuration by utilizing the following keys in the `consumes` section of the Specmatic Config:
 
 - `baseUrl`: Define the full URL, which includes the scheme, host and optionally port and path
-- `port`: Specify only the port. The host and scheme will utilize default values
-- `host`: Specify only the host. The scheme and port will utilize default values
-- `basePath`: Indicate a base path under which the stubs will be served. The scheme, host, and port will utilize default values
+- `port`: Specifies only the port, the rest will utilize default values
+- `host`: Specify only the host, the rest will utilize default values
+- `basePath`: Specifies only the basePath, the rest will utilize default values
 
-**Note:** If `baseUrl` is specified, the `host`, `port`, and `basePath` keys if present will be disregarded.
-Please refer to the order of precedence and the default values outlined below.
+The keys can be specified either individually or in combination. For more information on the override functionality, please consult the table below.  
+**Note**: `baseUrl` is mutually exclusive with the other fields — you must provide either `baseUrl` or one of or a combination of host, port and basePath.
 
-| Key In Order Of Precedence | What it Overrides              | Defaults Used      |
-|----------------------------|--------------------------------|--------------------|
-| baseUrl                    | Scheme, Host, Port, Path (All) | None               |
-| host                       | Host only                      | Scheme, Port       |
-| port                       | Port only                      | Scheme, Host       |
-| basePath                   | Path only                      | Scheme, Host, Port |
+| Key      | What it Overrides              | Defaults Used      |
+|----------|--------------------------------|--------------------|
+| baseUrl  | Scheme, Host, Port, Path (All) | None               |
+| host     | Host only                      | Scheme, Port, Path |
+| port     | Port only                      | Scheme, Host, Path |
+| basePath | Path only                      | Scheme, Host, Port |
 
-The default `baseUrl` can be customized through command-line arguments using `--host` and `--port`, which will construct the default `baseUrl`, or by configuring the `SPECMATIC_BASE_URL` system property. This provides the flexibility to easily adapt your stub servers to different local and remote environments as needed.
+The default `baseUrl` can be customized through command-line arguments using `--host` and `--port`, or by configuring the `SPECMATIC_BASE_URL` system property.
+This provides the flexibility to easily adapt your stub servers to different local and remote environments as needed.
 
 #### Example Specmatic Config
 
@@ -1821,19 +1822,36 @@ contracts:
   - filesystem:
       directory: "contracts"
     consumes:
-      - "com/order.yaml" # Utilizes the default baseUrl: http://0.0.0.0:9000
-      - baseUrl: "http://localhost:8080/api/v2" # Overrides the default baseUrl
+      - "com/order.yaml" # Default baseUrl: http://0.0.0.0:9000
+      - baseUrl: "http://127.0.0.1:8080/api/v2" 
         specs:
-          - "com/order.yaml"
-      - host: "127.0.0.1" # Host is overridden; other settings remain as default
+          - "com/order.yaml" # Overridden baseUrl: http://127.0.0.1:8080/api/v2
+      - host: "127.0.0.1"
         specs:
-          - "com/order.yaml"
-      - port: 8080 # Port is overridden; other settings remain as default
+          - "com/order.yaml" # Overridden host: http://127.0.0.1:9000
+      - port: 8080
         specs:
-          - "com/order.yaml"
-      - basePath: "/api/v2" # Path is overridden; scheme, host, and port remain as default
+          - "com/order.yaml" # Overridden port: http://0.0.0.0:8080
+      - basePath: "/api/v2"
         specs:
-          - "com/order.yaml"
+          - "com/order.yaml" # Overridden basePath: http://0.0.0.0:9000/api/v2
+      - host: "127.0.0.1"
+        port: 8080
+        specs:
+          - "com/order.yaml" # Overridden host and port: http://127.0.0.1:8080
+      - host: "127.0.0.1"
+        basePath: "/api/v2"
+        specs:
+          - "com/order.yaml" # Overridden host and basePath: http://127.0.0.1:9000/api/v2
+      - port: 8080
+        basePath: "/api/v2"
+        specs:
+          - "com/order.yaml" # Overridden port and basePath: http://0.0.0.0:8080/api/v2
+      - host: "127.0.0.1"
+        port: 8080
+        basePath: "/api/v2"
+        specs:
+          - "com/order.yaml" # Overridden host, port, and basePath: http://127.0.0.1:8080/api/v2
 ```
 
 ### Running Specmatic Stubs on Different BaseURLs


### PR DESCRIPTION
Specify how baseUrl, host, port, and basePath can be utilized in the Specmatic configuration for stubbing