### PR TITLE
Update Maven Central links for JAR artifacts

### DIFF
--- a/_includes/setup_command_line.md
+++ b/_includes/setup_command_line.md
@@ -16,12 +16,12 @@ docker run znsio/specmatic
 {% endtab %}
 
 {% tab install java %}
-Download the standalone jar from our [Github releases](<https://github.com/znsio/specmatic/releases/download/{{ site.latest_release }}/specmatic.jar>) or [Maven Central](https://repo1.maven.org/maven2/io/specmatic/specmatic-executable/{{ site.latest_release }}/specmatic-executable-{{ site.latest_release }}-all.jar).
+Download the standalone jar from our [Github releases](<https://github.com/znsio/specmatic/releases/download/{{ site.latest_release }}/specmatic.jar>) or [Maven Central](https://repo1.maven.org/maven2/io/specmatic/specmatic-executable-all/{{ site.latest_release }}/specmatic-executable-all-{{ site.latest_release }}.jar).
 
 If you have downloaded the standalone jar from Maven Central, you may want to rename it as shown below for convenience.
 
 ```bash
-mv specmatic-executable-{{ site.latest_release }}-all.jar specmatic.jar
+mv specmatic-executable-all-{{ site.latest_release }}.jar specmatic.jar
 ```
 
 Run specmatic as below to list all the options available

--- a/download.md
+++ b/download.md
@@ -8,7 +8,7 @@ Download
 
 Download the latest Specmatic standalone executable from the following sources:
 * [Github](https://github.com/znsio/specmatic/releases)
-* [Maven Central](https://repo1.maven.org/maven2/io/specmatic/specmatic-executable/{{ site.latest_release }}/specmatic-executable-{{ site.latest_release }}-all.jar)
+* [Maven Central](https://repo1.maven.org/maven2/io/specmatic/specmatic-executable-all/{{ site.latest_release }}/specmatic-executable-all-{{ site.latest_release }}.jar)
 * [Docker Hub](https://hub.docker.com/r/znsio/specmatic)
 
 Read our "[Getting started (in 5 min)](/getting_started.html)" section learn more about using the standalone executable.


### PR DESCRIPTION
Update Maven Central links for fat JAR artifacts `specmatic-executable`to `specmatic-executable-all`