### PR TITLE
Consistent Example Command Arguments

### DIFF
--- a/documentation/discriminator.md
+++ b/documentation/discriminator.md
@@ -287,7 +287,7 @@ a. Testing **Valid** Dog Request:
 Specmatic provides an interactive example generation interface. Let's start it with:
 
 ```bash
-specmatic examples interactive --contract-file=petstore.yaml
+specmatic examples interactive --spec-file=petstore.yaml
 ```
 
 This launches an interactive server and provides a URL [http://localhost:9001/_specmatic/examples](http://localhost:9001/_specmatic/examples). Opening this in your browser shows:

--- a/documentation/external_examples.md
+++ b/documentation/external_examples.md
@@ -113,12 +113,12 @@ To start the GUI execute below command,
 {% tabs examples-gui %}
 {% tab examples-gui docker %}
 ```shell
-docker run --rm -v "$(pwd):/specs" -p "9001:9001" znsio/specmatic-openapi examples interactive --contract-file /specs/employee_details.yaml
+docker run --rm -v "$(pwd):/specs" -p "9001:9001" znsio/specmatic-openapi examples interactive --spec-file /specs/employee_details.yaml
 ```
 {% endtab %}
 {% tab examples-gui java %}
 ```shell
-java -jar specmatic-openapi.jar examples interactive --contract-file employee_details.yaml
+java -jar specmatic-openapi.jar examples interactive --spec-file employee_details.yaml
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Use `--spec-file` instead of `--contract-file`