### PR TITLE
Documentation for config as template

### DIFF
--- a/references/configuration/index.md
+++ b/references/configuration/index.md
@@ -29,7 +29,9 @@ Note: Version 2 is the latest as of 14/02/2025. If you are looking for an older 
 - [Reports](reports.html) - Report generation and formatters
 - [Environments](environments.html) - Environment-specific configuration
 - [Hooks](hooks.html) - Custom commands and integrations
+- [Template Values](template-values.html) - Environment-driven configuration values
 - [Complete Examples](complete-examples.html) - Full configuration examples
+- [Upgrade Configuration](upgrade-specmatic-config.html) - Upgrading older configuration files
 
 ## Quick Start
 

--- a/references/configuration/template-values.md
+++ b/references/configuration/template-values.md
@@ -1,0 +1,108 @@
+---
+layout: default
+title: Template Values
+parent: Configuration
+grand_parent: References
+nav_order: 9
+---
+
+# Template Values
+
+Specmatic configuration supports simple template values so you can inject settings from environment variables or system properties.
+
+## Template Syntax
+
+Template values use the format:
+
+```
+{ENV_VAR_NAME:defaultValue}
+```
+
+Resolution order:
+
+1. Environment variable `ENV_VAR_NAME`
+2. System property `ENV_VAR_NAME`
+3. `defaultValue`
+
+## Scalar Examples
+
+{% tabs template_scalar %}
+{% tab template_scalar specmatic.yaml %}
+```yaml
+version: 2
+contracts: []
+stub:
+  generative: "{STUB_GENERATIVE:true}"
+```
+{% endtab %}
+{% tab template_scalar specmatic.json %}
+```json
+{
+  "version": 2,
+  "contracts": [],
+  "stub": {
+    "generative": "{STUB_GENERATIVE:true}"
+  }
+}
+```
+{% endtab %}
+{% endtabs %}
+
+Set the value in a shell (zsh/bash):
+
+```
+export STUB_GENERATIVE=false
+```
+
+## Structured Values (Object or Array)
+
+If the resolved value starts with `{` or `[`, it is parsed as JSON and used as an object or array value in the config.
+
+{% tabs template_structured %}
+{% tab template_structured specmatic.yaml %}
+```yaml
+version: 2
+contracts: []
+stub: "{STUB_CONFIG:{\"generative\": true}}"
+examples: "{EXAMPLE_DIRS:[\"examples/one\",\"examples/two\"]}"
+```
+{% endtab %}
+{% tab template_structured specmatic.json %}
+```json
+{
+  "version": 2,
+  "contracts": [],
+  "stub": "{STUB_CONFIG:{\"generative\": true}}",
+  "examples": "{EXAMPLE_DIRS:[\"examples/one\",\"examples/two\"]}"
+}
+```
+{% endtab %}
+{% endtabs %}
+
+Set the value in a shell:
+
+```
+export STUB_CONFIG='{"generative": false}'
+export EXAMPLE_DIRS='["examples/one","examples/two"]'
+```
+
+## Forcing a JSON-Looking String
+
+If the resolved value is a JSON string (quoted), Specmatic treats it as a string and removes the outer quotes. This lets you keep a JSON-looking value as plain text.
+
+Example:
+
+```
+export STUB_CONFIG='"{\"generative\": true}"'
+```
+
+Resulting value:
+
+```
+{"generative": true}
+```
+
+## Notes
+
+- JSON must be valid when using object/array templates.
+- Quoted JSON strings are treated as strings, not parsed into objects or arrays.

--- a/references/configuration/template-values.md
+++ b/references/configuration/template-values.md
@@ -8,7 +8,7 @@ nav_order: 9
 
 # Template Values
 
-Specmatic configuration supports simple template values so you can inject settings from environment variables or system properties.
+Specmatic configuration can pull in values from environment variables or system properties at runtime, through the use of template values.
 
 ## Template Syntax
 

--- a/references/configuration/template-values.md
+++ b/references/configuration/template-values.md
@@ -8,6 +8,13 @@ nav_order: 9
 
 # Template Values
 
+- [Template Values](#template-values)
+  - [Template Syntax](#template-syntax)
+  - [Scalar Examples](#scalar-examples)
+  - [Structured Values (Object or Array)](#structured-values-object-or-array)
+  - [Using a JSON-Looking Value As String](#using-a-json-looking-value-as-string)
+  - [Notes](#notes)
+
 Specmatic configuration can pull in values from environment variables or system properties at runtime, through the use of template values.
 
 ## Template Syntax
@@ -102,11 +109,28 @@ export STUB_CONFIG='{"generative": false}'
 export EXAMPLE_DIRS='["examples/one","examples/two"]'
 ```
 
-## Forcing a JSON-Looking String
+## Using a JSON-Looking Value As String
 
 If the resolved value is a JSON string (quoted), Specmatic treats it as a string and removes the outer quotes. This lets you keep a JSON-looking value as plain text.
 
 Example:
+
+{% tabs force-string %}
+{% tab force-string-yaml label="YAML" %}
+```yaml
+stub: "{STUB_CONFIG:\"{\\\"generative\\\": true}\"}"
+```
+{% endtab %}
+{% tab force-string-json label="JSON" %}
+```json
+{
+  "stub": "{STUB_CONFIG:\"{\\\"generative\\\": true}\"}"
+}
+```
+{% endtab %}
+{% endtabs %}
+
+Set the value in a shell:
 
 ```
 export STUB_CONFIG='"{\"generative\": true}"'

--- a/references/configuration/template-values.md
+++ b/references/configuration/template-values.md
@@ -30,7 +30,9 @@ Resolution order:
 {% tab template_scalar specmatic.yaml %}
 ```yaml
 version: 2
-contracts: []
+contracts:
+  - consumes:
+    - spec.yaml
 stub:
   generative: "{STUB_GENERATIVE:true}"
 ```
@@ -39,7 +41,13 @@ stub:
 ```json
 {
   "version": 2,
-  "contracts": [],
+  "contracts": [
+    {
+      "consumes": [
+        "spec.yaml"
+      ]
+    }
+  ],
   "stub": {
     "generative": "{STUB_GENERATIVE:true}"
   }
@@ -62,7 +70,9 @@ If the resolved value starts with `{` or `[`, it is parsed as JSON and used as a
 {% tab template_structured specmatic.yaml %}
 ```yaml
 version: 2
-contracts: []
+contracts:
+  - consumes:
+    - spec.yaml
 stub: "{STUB_CONFIG:{\"generative\": true}}"
 examples: "{EXAMPLE_DIRS:[\"examples/one\",\"examples/two\"]}"
 ```
@@ -71,7 +81,13 @@ examples: "{EXAMPLE_DIRS:[\"examples/one\",\"examples/two\"]}"
 ```json
 {
   "version": 2,
-  "contracts": [],
+  "contracts": [
+    {
+      "consumes": [
+        "spec.yaml"
+      ]
+    }
+  ],
   "stub": "{STUB_CONFIG:{\"generative\": true}}",
   "examples": "{EXAMPLE_DIRS:[\"examples/one\",\"examples/two\"]}"
 }

--- a/references/configuration/upgrade-specmatic-config.md
+++ b/references/configuration/upgrade-specmatic-config.md
@@ -3,7 +3,7 @@ layout: default
 title: Upgrade Configuration
 parent: Configuration
 grand_parent: References
-nav_order: 10
+nav_order: 11
 ---
 
 # Upgrade Older Configuration to the Latest Version


### PR DESCRIPTION
Added documentation on how to inject values from env/system property into config

Misc fixes:
- added missing upgrade linking into the index
- fixed nav_order conflict between docs on upgrade and complete examples