### PR TITLE
Add workflow feature documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ yarn-debug.log*
 yarn-error.log*
 
 **/build/reports/specmatic/
+
+*.iml

--- a/docs/features/index.mdx
+++ b/docs/features/index.mdx
@@ -10,6 +10,7 @@ Specmatic provides a rich set of features to help you with contract-driven devel
 * [Authentication](/features/authentication) - Configure authentication for your API tests
 * [Dictionary](/features/dictionary) - Define reusable data dictionaries
 * [External Examples](/features/external_examples) - Use external example files
+* [Workflow](/features/workflow) - Reuse response values across API tests
 * [Event Flow and Behaviour](/features/testing_event_flows-and_behaviors) - Define event flows and behaviours
 * [Overlays](/features/overlays) - Apply overlays to your specifications
 * [Feature Hub Stubbing](/features/stubbing_featurehub) - Stub FeatureHub feature flags

--- a/docs/features/workflow.mdx
+++ b/docs/features/workflow.mdx
@@ -1,0 +1,65 @@
+---
+title: Workflow
+sidebar_position: 5
+---
+
+# Workflow
+
+Workflow lets Specmatic carry data from one API test to another in the same test run.
+
+A common case is:
+- extract an id from a create response (`POST /orders -> 201`)
+- use that id in a later path parameter (`GET /orders/{orderId} -> 200`)
+
+## Configuration
+
+Define workflow rules in `specmatic.yaml`. For a complete configuration including version 2 format, see [Test Configuration](/references/configuration/test-configuration#workflow).
+
+### Version 3 style
+
+```yaml
+version: 3
+
+components:
+  runOptions:
+    orderApiTest:
+      openapi:
+        type: test
+        baseUrl: http://localhost:8080
+        workflow:
+          ids:
+            # Get the id from the test for the POST operation on /orders that expects a 201
+            "POST /orders -> 201":
+              extract: "BODY.id" # extract the id from this path in the response payload
+            # Use the id in other APIs where the `use` clause finds something
+            "*":
+              use: "PATH.orderId" # use the id at this point in the request for all operations
+
+systemUnderTest:
+  service:
+    $ref: "#/components/services/orderApiService"
+    runOptions:
+      $ref: "#/components/runOptions/orderApiTest"
+```
+
+## How It Works
+
+1. When a scenario configured with `extract` runs, Specmatic reads a value from the response body path.
+2. If there are multiple tests, the data extracted from the last test is used.
+3. When a later scenario configured with `use` runs, Specmatic substitutes that value into the configured path parameter.
+4. Specmatic validates the updated path against the contract. If the value type is wrong, the test fails.
+
+## Notes
+
+- `extract` does not support the wildcard fallback.
+- If you wish to use the id in only one API you can do so by using a specific workflow API selector such as "POST /orders/(id:string)", for example:
+    ```
+    workflow:
+      ids:
+        # Get the id from the test for the POST operation on /orders that expects a 201
+        "POST /orders -> 201":
+          extract: "BODY.id" # extract the id from this path in the response payload
+        # Use the id in other APIs where the `use` clause finds something
+        "*":
+          use: "PATH.orderId" # use the id at this point in the request for all operations
+    ```

--- a/docs/references/configuration/includes/test-configuration/v2/workflow/specmatic.json
+++ b/docs/references/configuration/includes/test-configuration/v2/workflow/specmatic.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "contracts": [
+    {
+      "provides": [
+        "./openapi/order.yaml"
+      ]
+    }
+  ],
+  "workflow": {
+    "ids": {
+      "POST /orders -> 201": {
+        "extract": "BODY.id"
+      },
+      "*": {
+        "use": "PATH.orderId"
+      }
+    }
+  }
+}

--- a/docs/references/configuration/includes/test-configuration/v3/workflow/specmatic.json
+++ b/docs/references/configuration/includes/test-configuration/v3/workflow/specmatic.json
@@ -1,0 +1,55 @@
+{
+  "version": 3,
+  "systemUnderTest": {
+    "service": {
+      "$ref": "#/components/services/orderApiService",
+      "runOptions": {
+        "$ref": "#/components/runOptions/orderApiTest"
+      }
+    }
+  },
+  "components": {
+    "sources": {
+      "localSpecs": {
+        "filesystem": {
+          "directory": "."
+        }
+      }
+    },
+    "services": {
+      "orderApiService": {
+        "description": "Order API Service",
+        "definitions": [
+          {
+            "definition": {
+              "source": {
+                "$ref": "#/components/sources/localSpecs"
+              },
+              "specs": [
+                "./openapi/order.yaml"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "runOptions": {
+      "orderApiTest": {
+        "openapi": {
+          "type": "test",
+          "baseUrl": "http://localhost:8080",
+          "workflow": {
+            "ids": {
+              "POST /orders -> 201": {
+                "extract": "BODY.id"
+              },
+              "*": {
+                "use": "PATH.orderId"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/references/configuration/test-configuration.mdx
+++ b/docs/references/configuration/test-configuration.mdx
@@ -60,6 +60,15 @@ Let's say you have a service that two specifications, or even multiple versions 
   v2Object={require('./includes/test-configuration/v2/multiple-test-base-url/specmatic.json')}
 />
 
+## Workflow
+
+You can configure workflow rules to extract data from one API response and use it in subsequent requests during contract testing.
+
+<V2V3SpecmaticConfigTabs
+  v3Object={require('./includes/test-configuration/v3/workflow/specmatic.json')}
+  v2Object={require('./includes/test-configuration/v2/workflow/specmatic.json')}
+/>
+
 ## Externalized Examples Directories
 
 By default, Specmatic searches for the directory ending with `_examples` to pickup externalized examples. However, if needed, you can specify a list of directories containing externalized examples under `examples` key in specmatic configuration. Specmatic will retrieve the examples from these directories for use in both contract testing and service virtualization.


### PR DESCRIPTION
Summary
- add workflow feature page that explains configuration, operation keys, and limitations
- link workflow from the features index and document it in the test configuration reference with v2/v3 snippets
- include workflow configuration examples for both v2 and v3 and keep dependencies in sync