### PR TITLE
docs: add web source contract-management configuration examples

### DIFF
--- a/docs/references/configuration/contract-management.mdx
+++ b/docs/references/configuration/contract-management.mdx
@@ -33,18 +33,6 @@ Configure Specmatic to pull contracts from a Git repository:
 
 
 
-## Contracts from Web Source
-
-If your specifications are hosted over HTTP(S), specify `web` field within contracts and set the source `url`:
-
-<V2V3SpecmaticConfigTabs
-  v3Object={require('./includes/contract-management/v3/web-configuration/specmatic.json')}
-  v2Object={require('./includes/contract-management/v2/web-configuration/specmatic.json')}
-  v2ObjectWithoutConfig={require('./includes/contract-management/v2/without-config/web-configuration/specmatic.json')}
-/>
-
-Specmatic resolves each specification path in `specs` relative to the configured web `url`.
-
 ## Contracts from Local Filesystem
 
 If you just need to use specifications from your local file system, specify `filesystem` field within contracts (if not
@@ -60,3 +48,15 @@ Note that the specification paths are relative paths. This means that they must 
 directory as the current directory.
 
 You can also provide absolute paths in case they are somewhere else on the filesystem.
+
+## Contracts from Web Source
+
+If your specifications are hosted over HTTP(S), specify `web` field within contracts and set the source `url`:
+
+<V2V3SpecmaticConfigTabs
+  v3Object={require('./includes/contract-management/v3/web-configuration/specmatic.json')}
+  v2Object={require('./includes/contract-management/v2/web-configuration/specmatic.json')}
+  v2ObjectWithoutConfig={require('./includes/contract-management/v2/without-config/web-configuration/specmatic.json')}
+/>
+
+Specmatic resolves each specification path in `specs` relative to the configured web `url`.

--- a/docs/references/configuration/contract-management.mdx
+++ b/docs/references/configuration/contract-management.mdx
@@ -32,6 +32,19 @@ Configure Specmatic to pull contracts from a Git repository:
 />
 
 
+
+## Contracts from Web Source
+
+If your specifications are hosted over HTTP(S), specify `web` field within contracts and set the source `url`:
+
+<V2V3SpecmaticConfigTabs
+  v3Object={require('./includes/contract-management/v3/web-configuration/specmatic.json')}
+  v2Object={require('./includes/contract-management/v2/web-configuration/specmatic.json')}
+  v2ObjectWithoutConfig={require('./includes/contract-management/v2/without-config/web-configuration/specmatic.json')}
+/>
+
+Specmatic resolves each specification path in `specs` relative to the configured web `url`.
+
 ## Contracts from Local Filesystem
 
 If you just need to use specifications from your local file system, specify `filesystem` field within contracts (if not

--- a/docs/references/configuration/includes/contract-management/v2/web-configuration/specmatic.json
+++ b/docs/references/configuration/includes/contract-management/v2/web-configuration/specmatic.json
@@ -1,0 +1,32 @@
+{
+  "version": 2,
+  "contracts": [
+    {
+      "web": {
+        "url": "https://contracts.example.com/specifications"
+      },
+      "provides": [
+        {
+          "specs": [
+            "io/specmatic/examples/store/openapi/online_store_v1.yaml"
+          ],
+          "specType": "openapi",
+          "config": {
+            "baseUrl": "http://localhost:8080"
+          }
+        }
+      ],
+      "consumes": [
+        {
+          "specs": [
+            "io/specmatic/examples/store/openapi/api_order_v1.yaml"
+          ],
+          "specType": "openapi",
+          "config": {
+            "baseUrl": "http://localhost:8090"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/references/configuration/includes/contract-management/v2/without-config/web-configuration/specmatic.json
+++ b/docs/references/configuration/includes/contract-management/v2/without-config/web-configuration/specmatic.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "contracts": [
+    {
+      "web": {
+        "url": "https://contracts.example.com/specifications"
+      },
+      "provides": [
+        "io/specmatic/examples/store/openapi/online_store_v1.yaml"
+      ],
+      "consumes": [
+        "io/specmatic/examples/store/openapi/api_order_v1.yaml"
+      ]
+    }
+  ]
+}

--- a/docs/references/configuration/includes/contract-management/v3/web-configuration/specmatic.json
+++ b/docs/references/configuration/includes/contract-management/v3/web-configuration/specmatic.json
@@ -1,0 +1,78 @@
+{
+  "version": 3,
+  "systemUnderTest": {
+    "service": {
+      "$ref": "#/components/services/onlineStoreServiceV1",
+      "runOptions": {
+        "$ref": "#/components/runOptions/onlineStoreServiceV1"
+      }
+    }
+  },
+  "dependencies": {
+    "services": [
+      {
+        "service": {
+          "$ref": "#/components/services/orderServiceV1",
+          "runOptions": {
+            "$ref": "#/components/runOptions/orderServiceV1"
+          }
+        }
+      }
+    ]
+  },
+  "components": {
+    "sources": {
+      "specmaticOrderContracts": {
+        "web": {
+          "url": "https://contracts.example.com/specifications"
+        }
+      }
+    },
+    "services": {
+      "onlineStoreServiceV1": {
+        "description": "Online Store Service (V1)",
+        "definitions": [
+          {
+            "definition": {
+              "source": {
+                "$ref": "#/components/sources/specmaticOrderContracts"
+              },
+              "specs": [
+                "io/specmatic/examples/store/openapi/online_store_v1.yaml"
+              ]
+            }
+          }
+        ]
+      },
+      "orderServiceV1": {
+        "description": "Payment Service (V1)",
+        "definitions": [
+          {
+            "definition": {
+              "source": {
+                "$ref": "#/components/sources/specmaticOrderContracts"
+              },
+              "specs": [
+                "io/specmatic/examples/store/openapi/api_order_v1.yaml"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "runOptions": {
+      "onlineStoreServiceV1": {
+        "openapi": {
+          "type": "test",
+          "baseUrl": "http://localhost:8080"
+        }
+      },
+      "orderServiceV1": {
+        "openapi": {
+          "type": "mock",
+          "baseUrl": "http://localhost:8090"
+        }
+      }
+    }
+  }
+}

--- a/docs/references/configuration/index.mdx
+++ b/docs/references/configuration/index.mdx
@@ -13,7 +13,7 @@ Note: Version 2 is the latest as of 14/02/2025. If you are using an older versio
 ## Configuration Topics
 
 - [Getting Started](/references/configuration/getting-started) - Basic setup and configuration upgrade
-- [Contract Management](/references/configuration/contract-management) - Managing contracts from Git or filesystem
+- [Contract Management](/references/configuration/contract-management) - Managing contracts from Git, web, or filesystem
 - [Test Configuration](/references/configuration/test-configuration) - Contract testing settings
 - [Mock Configuration](/references/configuration/mock-configuration) - Mock settings
 - [Reports](/references/configuration/reports) - Report generation and formatters


### PR DESCRIPTION
### Motivation
- The Specmatic configuration gained support for a `web`/`webBaseUrl` source provider, so the contract management docs needed matching examples and guidance for users to consume specs over HTTP(S).
- Keep the new documentation consistent with the existing `git` and `filesystem` sections and show v2/v3 usage patterns.

### Description
- Added a new **Contracts from Web Source** section to `docs/references/configuration/contract-management.mdx` that explains the `web` source and notes that `specs` paths are resolved relative to the configured `url`.
- Added example configuration files for the web source: `v3/web-configuration/specmatic.json`, `v2/web-configuration/specmatic.json`, and `v2/without-config/web-configuration/specmatic.json` under `docs/references/configuration/includes/contract-management`.
- Wired the new examples into the existing `V2V3SpecmaticConfigTabs` component so the web examples appear alongside the git and filesystem tabs.
- Updated the configuration index blurb to mention contract sources can be from Git, web, or filesystem.

### Testing
- Ran JSON validation with `jq empty` against the three newly added example files and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f614f8048327b4620311dae57a2e)