### PR TITLE
docs: expand SCIM audit event details

### DIFF
--- a/docs/enterprise_onboarding/audit-event-reference.mdx
+++ b/docs/enterprise_onboarding/audit-event-reference.mdx
@@ -1210,14 +1210,41 @@ Common `details` fields for all SCIM provisioning events:
 | `details.status`         | `string`  | Provisioning outcome status; currently `SUCCESS`.                                                            |
 | `details.idempotencyKey` | `string`  | Request key recorded with the audit event for traceability across retries/call chains.                       |
 
-Optional `details` fields by resource type:
+User-specific `details` fields (`SCIM_USER_*`):
 
-| field name                   | data type | emitted for    | description                                                        |
-|------------------------------|-----------|----------------|--------------------------------------------------------------------|
-| `details.userName`           | `string`  | `SCIM_USER_*`  | Canonical SCIM `userName` value persisted for the user link.       |
-| `details.projectedUserEmail` | `string`  | `SCIM_USER_*`  | Email on projected local user when user projection/linkage exists. |
-| `details.displayName`        | `string`  | `SCIM_GROUP_*` | Canonical SCIM group display name at mutation time.                |
-| `details.externalId`         | `string`  | both           | Optional IdP-provided external correlation id.                     |
+| field name                   | data type | description                                                                          |
+|------------------------------|-----------|--------------------------------------------------------------------------------------|
+| `details.userName`           | `string`  | Canonical SCIM `userName` value persisted for the user link.                         |
+| `details.projectedUserEmail` | `string`  | Email on projected local user when user projection/linkage exists.                   |
+| `details.externalId`         | `string`  | Optional IdP-provided external correlation id.                                       |
+| `details.active`             | `boolean` | Current SCIM active state captured on the audit event (present for all user events). |
+| `details.before`             | `object`  | Snapshot before mutation for `UPDATE`/`PATCH`/`DEACTIVATE`/`REACTIVATE` operations.  |
+| `details.after`              | `object`  | Snapshot after mutation for `UPDATE`/`PATCH`/`DEACTIVATE`/`REACTIVATE` operations.   |
+
+User snapshot shape (`details.before` / `details.after`):
+
+| field name             | data type | description                                  |
+|------------------------|-----------|----------------------------------------------|
+| `*.userName`           | `string`  | User name at that point in time.             |
+| `*.projectedUserEmail` | `string`  | Projected local email at that point in time. |
+| `*.externalId`         | `string`  | External id at that point in time.           |
+| `*.active`             | `boolean` | Active flag at that point in time.           |
+
+Group-specific `details` fields (`SCIM_GROUP_*`):
+
+| field name            | data type | description                                                              |
+|-----------------------|-----------|--------------------------------------------------------------------------|
+| `details.displayName` | `string`  | Canonical SCIM group display name at mutation time.                      |
+| `details.externalId`  | `string`  | Optional IdP-provided external correlation id.                           |
+| `details.before`      | `object`  | Snapshot before mutation for `UPDATE` and `PATCH` group operations only. |
+| `details.after`       | `object`  | Snapshot after mutation for `UPDATE` and `PATCH` group operations only.  |
+
+Group snapshot shape (`details.before` / `details.after`):
+
+| field name            | data type | description                           |
+|-----------------------|-----------|---------------------------------------|
+| `*.displayName`       | `string`  | Display name at that point in time.   |
+| `*.externalId`        | `string`  | External id at that point in time.    |
 
 #### `SCIM_USER_CREATED`
 
@@ -1253,7 +1280,8 @@ Example event:
     "idempotencyKey": "b48607d6-f5eb-4851-9252-f8f179583303",
     "userName": "user@example.com",
     "projectedUserEmail": "user@example.com",
-    "externalId": "ext-user"
+    "externalId": "ext-user",
+    "active": true
   }
 }
 ```
@@ -1292,7 +1320,20 @@ Example event:
     "idempotencyKey": "43af4f5d-a347-4665-b8fb-3d807b315603",
     "userName": "user.updated@example.com",
     "projectedUserEmail": "user.updated@example.com",
-    "externalId": "ext-user-updated"
+    "externalId": "ext-user-updated",
+    "active": true,
+    "before": {
+      "userName": "user@example.com",
+      "projectedUserEmail": "user@example.com",
+      "externalId": "ext-user",
+      "active": true
+    },
+    "after": {
+      "userName": "user.updated@example.com",
+      "projectedUserEmail": "user.updated@example.com",
+      "externalId": "ext-user-updated",
+      "active": true
+    }
   }
 }
 ```
@@ -1331,7 +1372,20 @@ Example event:
     "idempotencyKey": "e9972cf7-b6f7-4704-8f88-ee61c766f2fb",
     "userName": "user.updated@example.com",
     "projectedUserEmail": "user.updated@example.com",
-    "externalId": "ext-user-patched"
+    "externalId": "ext-user-patched",
+    "active": true,
+    "before": {
+      "userName": "user.updated@example.com",
+      "projectedUserEmail": "user.updated@example.com",
+      "externalId": "ext-user-updated",
+      "active": true
+    },
+    "after": {
+      "userName": "user.updated@example.com",
+      "projectedUserEmail": "user.updated@example.com",
+      "externalId": "ext-user-patched",
+      "active": true
+    }
   }
 }
 ```
@@ -1370,7 +1424,8 @@ Example event:
     "idempotencyKey": "03e04af8-7259-4ab3-ac4b-bfd7b82a9e80",
     "userName": "user.updated@example.com",
     "projectedUserEmail": "user.updated@example.com",
-    "externalId": "ext-user-patched"
+    "externalId": "ext-user-patched",
+    "active": false
   }
 }
 ```
@@ -1409,7 +1464,8 @@ Example event:
     "idempotencyKey": "cf08be29-f9f1-4967-a77a-18926ec191f5",
     "userName": "user.updated@example.com",
     "projectedUserEmail": "user.updated@example.com",
-    "externalId": "ext-user-patched"
+    "externalId": "ext-user-patched",
+    "active": true
   }
 }
 ```
@@ -1448,7 +1504,8 @@ Example event:
     "idempotencyKey": "user:delete:4b56c08a-8565-47cb-af3d-76260da123fe:7df77c20-2d76-490a-8f14-f04288076926",
     "userName": "user@example.com",
     "projectedUserEmail": "user@example.com",
-    "externalId": "ext-user"
+    "externalId": "ext-user",
+    "active": false
   }
 }
 ```
@@ -1524,7 +1581,15 @@ Example event:
     "status": "SUCCESS",
     "idempotencyKey": "group:update:d8d7cf67-3d25-4cde-a3be-4798ba45b742",
     "displayName": "Platform Team Updated",
-    "externalId": "ext-platform-team-updated"
+    "externalId": "ext-platform-team-updated",
+    "before": {
+      "displayName": "Platform Team",
+      "externalId": "ext-platform-team"
+    },
+    "after": {
+      "displayName": "Platform Team Updated",
+      "externalId": "ext-platform-team-updated"
+    }
   }
 }
 ```
@@ -1562,7 +1627,15 @@ Example event:
     "status": "SUCCESS",
     "idempotencyKey": "group:patch:d8d7cf67-3d25-4cde-a3be-4798ba45b742",
     "displayName": "Platform Team",
-    "externalId": "ext-platform-team"
+    "externalId": "ext-platform-team",
+    "before": {
+      "displayName": "Platform Team Updated",
+      "externalId": "ext-platform-team-updated"
+    },
+    "after": {
+      "displayName": "Platform Team",
+      "externalId": "ext-platform-team"
+    }
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
       "integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.51.0",
         "@algolia/requester-browser-xhr": "5.51.0",
@@ -307,6 +308,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2146,6 +2148,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2168,6 +2171,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2277,6 +2281,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2698,6 +2703,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3610,6 +3616,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.1.tgz",
       "integrity": "sha512-XTZhE5C1gZ/DaYYMlSk02dwP5vhpQON5QHVz1s3892mSESAywgWanURpXEDAvt4GvGuq7s+XP8rTWHZvfaJmdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/types": "3.10.1",
         "@rspack/core": "^1.7.10",
@@ -3765,6 +3772,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -4034,6 +4042,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
       "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.10.1",
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -4956,6 +4965,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5187,9 +5197,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5205,9 +5212,6 @@
       "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5225,9 +5229,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5243,9 +5244,6 @@
       "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5601,9 +5599,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5616,9 +5611,6 @@
       "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5633,9 +5625,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5648,9 +5637,6 @@
       "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5959,6 +5945,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6063,6 +6050,7 @@
       "integrity": "sha512-/eWL0n43D64QWEUHLtTE+jDqjkJhyidjkDhv6f0uJohOUAhywxQ9wXYp845DNNds0JpCdI4Uo0a9bl+vbXf+ew==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -6152,9 +6140,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6170,9 +6155,6 @@
       "integrity": "sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6190,9 +6172,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6208,9 +6187,6 @@
       "integrity": "sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6228,9 +6204,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6246,9 +6219,6 @@
       "integrity": "sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6394,9 +6364,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6412,9 +6379,6 @@
       "integrity": "sha512-iTrXjSeVwhHp+w7I5srCSpG9prebj+j/lmWalljNXGagTuVmtEWdH/EDvtSq1JfJyKQ6KRKyeB3Qg6yGHhjr+Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6432,9 +6396,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6450,9 +6411,6 @@
       "integrity": "sha512-zBavh0QnsvjM9QMPmtOqMaUGSLr5tdj2gxEx4xXzOXBFkUKKRA+qEfx6LdTzIbrqqtK5Xf6CPBPT9kzhDLuaCA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -6470,9 +6428,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6488,9 +6443,6 @@
       "integrity": "sha512-wRXdcS0eaYU1Pm15gNGmVM7fsJ/xCxy3BnfNH52MC/ObgCIzBcFl3Yjn6yr6nkqNtDZyEt8IlQFQno5zEEvIpw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -7121,6 +7073,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7481,6 +7434,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7548,6 +7502,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7593,6 +7548,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
       "integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.17.0",
         "@algolia/client-abtesting": "5.51.0",
@@ -8081,6 +8037,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8390,6 +8347,7 @@
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -9100,6 +9058,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9420,6 +9379,7 @@
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9864,6 +9824,7 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11052,6 +11013,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12997,9 +12959,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13019,9 +12978,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -13043,9 +12999,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13065,9 +13018,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -15929,6 +15879,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16524,6 +16475,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17427,6 +17379,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18255,6 +18208,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18264,6 +18218,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18319,6 +18274,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -18347,6 +18303,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -20176,7 +20133,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -20600,6 +20558,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20857,6 +20816,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",


### PR DESCRIPTION
## Summary
- expand SCIM audit event docs with user/group specific detail fields
- document before/after snapshot shapes for update and patch flows
- update SCIM event examples to include active and before/after details
- include generated package-lock.json updates

## Testing
- not run (docs + lockfile update)