### PR TITLE
Fix typos in document

### DIFF
--- a/docs/contract_driven_development/contract_testing.mdx
+++ b/docs/contract_driven_development/contract_testing.mdx
@@ -550,7 +550,7 @@ Remarks are displayed for each row in table and act as a summary of the tests ex
 | **Missing In Spec** | The endpoint is implemented on the service but isn't documented in the OpenAPI Specification                                   |
 | **Not Implemented** | The endpoint is documented in the OpenAPI Specification but isn't implemented by the service                                   |
 | **Not Covered**     | Tests for this group were not executed or were skipped                                                                         |
-| **WIP**             | This endpoint is marked WIP in the OpenAPI Specification, Any failures in this grouped are indicated by yellow and disregarded |
+| **WIP**             | This endpoint is marked WIP in the OpenAPI Specification. Any failures in this group are indicated by yellow and disregarded   |
 | **Invalid**         | The endpoint doesn't conform to REST standards                                                                                 |
 
 **Note**: The remarks `Missing In Spec` and `Not Implemented` are contingent upon the actuator being enabled. Please refer to [API Coverage](#api-coverage) for further details.
@@ -784,7 +784,7 @@ A **202 Accepted** HTTP status code indicates that a request has been accepted f
 
 
 - The specification must define a **202 Accepted** response for the specific path and HTTP method
-- The response must include a [Link Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link) with an `title` parameter set to `"monitor"`
+- The response must include a [Link Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link) with a `title` parameter set to `"monitor"`
 - The specification must also include an operation that corresponds to the URL provided in the [Link Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link), on which Specmatic can **poll** for the completion of the operation
 - The response from the polled endpoint must conform to a standard schema
 - By default, a maximum of **3** monitoring attempts will be executed before the test fail, with delay resulting from the [Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After) Header if present, or exponential backoff otherwise

--- a/docs/contract_driven_development/service_virtualization.mdx
+++ b/docs/contract_driven_development/service_virtualization.mdx
@@ -757,7 +757,7 @@ The same idea extends to the response.
 
 ## Use Meaningful Response Values From An External Dictionary
 
-When Specmatic's mock receives a request and finds no matching examples for it, Specmatic returns a response generated from the response schema in the API specification. While the generated response is schema-valid, it will not have meaningful values drawn from the context of your business domain. So in order to get domain-relevant responses when there examples, you can provide a dictionary of sample values to Specmatic. Specmatic will look up this dictionary when it needs to generate domain-relevant examples.
+When Specmatic's mock receives a request and finds no matching examples for it, Specmatic returns a response generated from the response schema in the API specification. While the generated response is schema-valid, it will not have meaningful values drawn from the context of your business domain. So in order to get domain-relevant responses with the examples, you can provide a dictionary of sample values to Specmatic. Specmatic will look up this dictionary when it needs to generate domain-relevant examples.
 
 Refer to [Dictionary with service virtualization](/features/dictionary#dictionary-with-service-virtualization) for more details.
 

--- a/docs/features/dictionary.mdx
+++ b/docs/features/dictionary.mdx
@@ -72,7 +72,7 @@ Employee:
 
 ### Parameters Mapping
 
-In the `PARAMETERS` section, parameters should organized based on their location: `PATH`, `QUERY`, or `HEADER`. Each key within these groups denotes the parameter name, which may correspond to either a singular value or an array of potential values. When multiple values are specified, one will be selected pseudo-randomly during runtime.
+In the `PARAMETERS` section, parameters should be organized based on their location: `PATH`, `QUERY`, or `HEADER`. Each key within these groups denotes the parameter name, which may correspond to either a singular value or an array of potential values. When multiple values are specified, one will be selected pseudo-randomly during runtime.
 
 <Tabs groupId="parameters">
 
@@ -118,7 +118,7 @@ PARAMETERS:
 
 ### Nested Properties
 
-For nested structures, properties are represented as nested keys, where each level corresponds to a that level in the schema hierarchy.
+For nested structures, properties are represented as nested keys, where each level corresponds to that level in the schema hierarchy.
 For example, given the `Employee` schema as follows:
 
 ```yaml
@@ -265,7 +265,7 @@ It is also not necessary to specify all properties of the object within the arra
 
 ### Referencing Other Schemas
 
-When a schema component utilizes `$ref` to reference another schema component, the dictionary for the referenced schema component with be defined with that schema component as the root entry (in other words directly start with the fields of the referenced schema)<br/>
+When a schema component utilizes `$ref` to reference another schema component, the dictionary for the referenced schema component will be defined with that schema component as the root entry (in other words directly start with the fields of the referenced schema)<br/>
 For example, given the following `Employee` and `Address` schemas:
 
 ```yaml

--- a/docs/features/overlays.mdx
+++ b/docs/features/overlays.mdx
@@ -157,10 +157,10 @@ Requires exact naming pattern with underscore: _overlay.yaml
 
 The environment variable approach is particularly useful when:
 
-Running tests programmatically
-Setting up CI/CD pipelines
-Working with test frameworks
-Need to specify overlays globally for multiple test runs
+  - Running tests programmatically
+  - Setting up CI/CD pipelines
+  - Working with test frameworks
+  - Need to specify overlays globally for multiple test runs
 
 #### Step 3: Understanding the Results
 When Specmatic runs the tests, it will send requests with the modified headers:

--- a/docs/getting_started/studio_quick_start.mdx
+++ b/docs/getting_started/studio_quick_start.mdx
@@ -161,7 +161,7 @@ It will always return below values:
 }
 ```
 
-This is thanks to the example `SCOOBY_200_OK` in the `petstore.yaml` spec file, which we earlier saw being used while running contract test. Specmatic also uses it to serves a mock response.
+This is thanks to the example `SCOOBY_200_OK` in the `petstore.yaml` spec file, which we earlier saw being used while running contract test. Specmatic also uses it to serve a mock response.
 
 With this we have effectively achieved three goals in one go.
 * Examples serve as sample data for people referring to the API specification as documentation


### PR DESCRIPTION
This pull request fixes typos in the documentation passages related to "Dictionary", "Service Virtualization", "Contract Testing", "Overlays", and "Studio Quick Start".