### PR TITLE
mention deprecated report paths

### DIFF
--- a/docs/contract_driven_development/contract_testing.mdx
+++ b/docs/contract_driven_development/contract_testing.mdx
@@ -626,6 +626,15 @@ Test qualifiers are displayed for each test and provide additional context about
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Undeclared Response** | The test received a response that was not declared in the specification. This means the observed response identifiers did not match any expected response identifiers.                   |
 
+#### Deprecated Contract Test Reports
+
+The legacy contract test report artifacts have been deprecated and removed. This includes:
+* The legacy HTML report at `./build/reports/specmatic/html/index.html`.
+* The legacy OpenAPI coverage report at `./build/reports/specmatic/coverage_report.json`.
+* The legacy AsyncAPI coverage report at `./build/reports/specmatic/async/coverage-report.json`.
+* The legacy gRPC coverage report at `./build/reports/specmatic/grpc/coverage-report.json`.
+
+Please use the HTML and CTRF reports described above.
 
 ### Examples that are not passing yet
 

--- a/docs/contract_driven_development/service_virtualization.mdx
+++ b/docs/contract_driven_development/service_virtualization.mdx
@@ -1391,6 +1391,14 @@ Remarks are displayed for each operation and act as a summary of the tests execu
 | **Missing In Spec** | The interaction was observed but is not defined in the specification.                              |
 | **Mismatch**        | The interaction was observed, but one or more identifiers did not match the specification.         |
 
+#### Deprecated Mock Usage Reports
+
+The legacy mock usage report artifacts have been deprecated and removed. This includes:
+* The legacy OpenAPI report at `./build/reports/specmatic/stub_usage_report.json`.
+* The legacy AsyncAPI report at `./build/reports/specmatic/async/stub_usage_report.json`.
+* The legacy gRPC report at `./build/reports/specmatic/grpc/stub-usage-report.json`.
+
+Please use the HTML and CTRF reports described above.
 
 ## Sample Java Project
 


### PR DESCRIPTION
- Add dedicated deprecated report sections for test and mock
- So Migrators can find the old paths and move to the new HTML/CTRF artifacts.