### PR TITLE
Document nested query parameter serialization and validation rules

### DIFF
--- a/docs/features/index.mdx
+++ b/docs/features/index.mdx
@@ -11,6 +11,7 @@ Specmatic provides a rich set of features to help you with contract-driven devel
 * [Dictionary](/features/dictionary) - Define reusable data dictionaries
 * [External Examples](/features/external_examples) - Use external example files
 * [Matchers](/features/matchers) - Match dynamic request and response values in mocks and contract tests
+* [Parameter Serialization](/features/openapi/parameter_serialization) - Serialize OpenAPI object and nested query parameters
 * [Workflow](/features/workflow) - Chain a sequence of API calls into a workflow, binding them by passing data from one to the next
 * [Event Flows and Behaviour](/features/testing_event_flows-and_behaviors) - Define event flows and behaviours
 * [Overlays](/features/overlays) - Apply overlays to your specifications

--- a/docs/features/openapi/_category_.json
+++ b/docs/features/openapi/_category_.json
@@ -1,0 +1,4 @@
+{
+    "label": "OpenAPI",
+    "position": 8
+}

--- a/docs/features/openapi/parameter_serialization.mdx
+++ b/docs/features/openapi/parameter_serialization.mdx
@@ -1,0 +1,156 @@
+---
+title: Parameter Serialization
+sidebar_position: 1
+---
+
+# Parameter Serialization
+
+Specmatic supports OpenAPI query parameter objects serialized with `style: form` and `explode: true`.
+This is also the OpenAPI default for query parameters when `style` and `explode` are omitted.
+
+## Form exploded object query parameters
+
+For an object query parameter with scalar properties, the wire representation uses the property names directly.
+
+```yaml
+parameters:
+  - in: query
+    name: details
+    schema:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+```
+
+The `details` object above can be sent as:
+
+```http
+GET /employees?name=Jack&age=30
+```
+
+Specmatic uses this representation in contract tests, mocks, examples validation and fixing, and when generating query parameters.
+
+## Nested objects and arrays
+
+OpenAPI 3.0 parameter serialization does not define a standard wire format for nested object or array properties inside an object query parameter declared with `style: form` and `explode: true`. Different HTTP frameworks use different conventions.
+
+Specmatic supports nested object and array query parameters.
+
+Specmatic uses inline OpenAPI parameter examples as syntax hints while parsing the specification. These examples tell Specmatic which query key notation your API expects.
+
+So if you have an API with nested objects or arrays, provide an example.
+
+### Properties
+
+Nested object properties can be serialized using dot notation or bracket notation.
+Dot notation is the default when examples do not provide any other property notation guidance.
+
+#### Dot properties
+
+```yaml
+examples:
+  dotProperties:
+    value: "price.min=10&price.max=100"
+```
+
+This represents query keys such as:
+
+```http
+GET /products?price.min=10&price.max=100
+```
+
+#### Bracket properties
+
+```yaml
+examples:
+  bracketProperties:
+    value: "price[min]=10&price[max]=100"
+```
+
+This represents query keys such as:
+
+```http
+GET /products?price[min]=10&price[max]=100
+```
+
+### Arrays
+
+Arrays currently use `[index]` notation.
+
+```yaml
+examples:
+  indexedArray:
+    value: "errors[0].code=invalid_name&errors[0].message=Name%20is%20required"
+```
+
+This represents query keys such as:
+
+```http
+GET /reports?errors[0].code=invalid_name&errors[0].message=Name%20is%20required
+```
+
+### Wrapped root
+
+For `style: form` and `explode: true`, OpenAPI serializes object properties directly as query keys. Some HTTP frameworks instead expect the query parameter name to wrap the serialized object. Use inline examples to show Specmatic when your API expects this wrapper.
+
+#### Wrapped root with brackets
+
+Some frameworks include the parameter name as a wrapper around the query object.
+
+```yaml
+parameters:
+  - in: query
+    name: details
+    schema:
+      type: object
+    examples:
+      wrappedBrackets:
+        value: "details[name]=Jack&details[address][0].street=Main%20Street"
+```
+
+This represents query keys such as:
+
+```http
+GET /employees?details[name]=Jack&details[address][0].street=Main%20Street
+```
+
+#### Wrapped root with dot
+
+```yaml
+parameters:
+  - in: query
+    name: details
+    schema:
+      type: object
+    examples:
+      wrappedDot:
+        value: "details.name=Jack&details.address[0].street=Main%20Street"
+```
+
+This represents query keys such as:
+
+```http
+GET /employees?details.name=Jack&details.address[0].street=Main%20Street
+```
+
+## How Specmatic uses examples
+
+Specmatic looks at inline parameter `example` and `examples` values when parsing the OpenAPI specification.
+The hints may be split across multiple inline parameter examples. As long as there are samples of the query parameter syntax for nested arrays or objects across inline examples of that API in the spec, Specmatic will pick it up and use it for running tests, validating examples, and serving mocks.
+
+## Conflicting syntax
+
+Specmatic rejects conflicting syntax in the same example.
+For example, the following example mixes dot property notation and bracket property notation:
+
+```yaml
+examples:
+  conflicting:
+    value: "errors[0].code=invalid_name&method[status]=failed"
+```
+
+`errors[0].code` uses dot property notation, while `method[status]` uses bracket property notation.
+Use one property notation consistently in a single example.

--- a/src/pages/rules/index.mdx
+++ b/src/pages/rules/index.mdx
@@ -54,6 +54,10 @@ search_exclude: true
     * [Required query object conflict](#required-query-object-conflict)
   * [OAS0013](#oas0013)
     * [Query parameter type collision](#query-parameter-type-collision)
+  * [OAS0014](#oas0014)
+    * [Invalid nested query parameter example](#invalid-nested-query-parameter-example)
+  * [OAS0015](#oas0015)
+    * [Unsupported nested query parameter schema](#unsupported-nested-query-parameter-schema)
   * [OAS0020](#oas0020)
     * [Security property redefined](#security-property-redefined)
   * [OAS0021](#oas0021)
@@ -901,6 +905,118 @@ In this example, the form-exploded `info` object contributes the wire key `age` 
 - Keep both declarations only if they resolve to the same schema for the same wire key.
 - Rename or restructure one of the parameters so they no longer serialize to the same query-string key.
 - If the wire key must stay the same, align the schemas so Specmatic does not have to choose between conflicting definitions.
+
+## OAS0014
+
+### Invalid nested query parameter example
+
+Nested query parameter examples must use valid keys that match the parameter schema and the nested query syntax inferred by Specmatic.
+
+**Why this is a problem**
+
+Specmatic expands nested object query parameters from the example keys. Malformed keys, unknown properties, scalar fields followed by nested tokens, array indexes expressed as property names, or mixed nested property styles make the intended query shape ambiguous.
+
+Example:
+
+```yaml
+parameters:
+  - in: query
+    name: filter
+    style: form
+    explode: true
+    schema:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              code:
+                type: string
+        method:
+          type: object
+          properties:
+            status:
+              type: string
+        profile:
+          type: object
+          properties:
+            name:
+              type: string
+    examples:
+      invalid:
+        value: "errors[0].code=E001&method[status]=failed&profile[[name=alice"
+```
+
+The example mixes `errors[0].code` with `method[status]`, which uses conflicting nested property serialization styles in the same example. The `profile[[name` key is malformed and cannot be parsed as a valid nested query key.
+
+**How this can be resolved**
+
+- Use one supported nested query key style consistently within the example.
+- Fix malformed keys and ensure every nested key maps to a property declared in the query parameter schema.
+- Rewrite invalid scalar or array paths so scalar properties are not followed by nested tokens, and arrays use numeric indexes where indexes are expected.
+
+## OAS0015
+
+### Unsupported nested query parameter schema
+
+Nested query parameter schemas must be concrete enough for Specmatic to derive a safe nested query shape.
+
+**Why this is a problem**
+
+Specmatic cannot safely infer nested query keys from ambiguous or unsupported schema shapes. Composed schemas such as `oneOf`, `anyOf`, or `allOf` under nested query object properties are not supported for this feature. Array query schemas must also declare `items`.
+
+Example:
+
+```yaml
+parameters:
+  - in: query
+    name: filter
+    style: form
+    explode: true
+    schema:
+      type: object
+      properties:
+        criteria:
+          oneOf:
+            - type: object
+              properties:
+                status:
+                  type: string
+            - type: object
+              properties:
+                code:
+                  type: string
+```
+
+Specmatic cannot determine a single nested query shape for `criteria` because it can match more than one composed schema branch.
+
+**How this can be resolved**
+
+- Replace composed nested query schemas with a concrete object schema for query parameters.
+- Move ambiguous alternatives into separate query parameters when they represent different request shapes.
+- Add `items` to array query schemas so Specmatic can derive the nested array element shape.
+
+For example:
+
+```yaml
+parameters:
+  - in: query
+    name: filter
+    style: form
+    explode: true
+    schema:
+      type: object
+      properties:
+        criteria:
+          type: object
+          properties:
+            status:
+              type: string
+            code:
+              type: string
+```
 
 ## OAS0020
 


### PR DESCRIPTION
## Summary
- Add a new OpenAPI Parameter Serialization feature page covering form-exploded query objects, nested object and array notation, and inline example hints.
- Add OAS0014 and OAS0015 rules for invalid nested query examples and unsupported nested query schemas.
- Link the new feature from the main features index and register it under the OpenAPI docs section.

## Testing
- Not run (not requested)